### PR TITLE
feat: avoid workflow duplication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev pkg-config
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.ref_name }}
+          path: dist/
+
+      # Publish to PyPI using Trusted Publishers
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+          verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Semantic Release
 
 on:
   push:
@@ -29,22 +29,6 @@ jobs:
           # Note: this must be done differently in an organization account
           # as we can bypass the specific actor_id
           token: ${{ secrets.SEMANTIC_RELEASE_ADMIN_TOKEN }}
-
-      - name: Get Semantic Release App Actor ID
-        run: |
-          SEMANTIC_RELEASE_ACTOR_ID=$(gh api "users/semantic-release[bot]" --jq '.id')
-          echo "The actor_id for semantic-release[bot] is: $SEMANTIC_RELEASE_ACTOR_ID"
-          echo "SEMANTIC_RELEASE_ACTOR_ID=$SEMANTIC_RELEASE_ACTOR_ID" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Semantic Release App Actor ID
-        run: |
-          SEMANTIC_RELEASE_ACTOR_ID=$(gh api "users/semantic-release[bot]" --jq '.id')
-          echo "The actor_id for semantic-release[bot] is: $SEMANTIC_RELEASE_ACTOR_ID"
-          echo "SEMANTIC_RELEASE_ACTOR_ID=$SEMANTIC_RELEASE_ACTOR_ID" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -89,51 +73,3 @@ jobs:
           cat /tmp/semantic-release.log || echo "No log available"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-and-publish:
-    runs-on: ubuntu-latest
-    needs: semantic-release
-    if: needs.semantic-release.outputs.released == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.semantic-release.outputs.tag }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsystemd-dev pkg-config
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine
-
-      - name: Build package
-        run: python -m build
-
-      - name: Check package
-        run: twine check dist/*
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions-${{ needs.semantic-release.outputs.version }}
-          path: dist/
-
-      # Note: GitHub release is automatically created by semantic-release
-      # with upload_to_vcs_release = true in pyproject.toml
-
-      # Publish to PyPI using Trusted Publishers
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          print-hash: true
-          verbose: true


### PR DESCRIPTION
Separate the release and publish workflows to avoid dual workflow runs for merge and tag.