### PR TITLE
feat: avoid workflow duplication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ permissions:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
-    outputs:
-      released: ${{ steps.semantic.outputs.released }}
-      version: ${{ steps.semantic.outputs.version }}
-      tag: ${{ steps.semantic.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Separate the release and publish workflows to avoid dual workflow runs for merge and tag.