### PR TITLE
fix: configure semantic-release not to create tag commits

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,10 +6,6 @@ on:
     branches: [master, main, maint]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   commit-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
     branches: [master, main, maint]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
This will avoid duplicated workflow runs